### PR TITLE
Send flush parameter to end()

### DIFF
--- a/src/dump.coffee
+++ b/src/dump.coffee
@@ -25,7 +25,7 @@ class RedisDumper
 
     close: ->
         # Close redis connection
-        @db.end()
+        @db.end(true)
 
     escape: (value) ->
         if /^([a-zA-Z0-9_\:\-]+)$/.test "#{value}"


### PR DESCRIPTION
According to https://github.com/NodeRedis/node_redis#clientendflush
is now mandatory