### PR TITLE
Sanity check for existence of object before assigning a key

### DIFF
--- a/bin/dump.js
+++ b/bin/dump.js
@@ -305,7 +305,7 @@
                         };
                     }
                     ttl = parseInt(ttls[i], 10);
-                    if (!isNaN(ttl) && ttl !== -1) {
+                    if (!isNaN(ttl) && ttl !== -1 && json[key]) {
                       json[key].ttl = ttl;
                     }
                   }


### PR DESCRIPTION
https://github.com/jeremyfa/node-redis-dump/issues/19

I don't know the root cause of this error, but likely the switch statement above does not handle all possible cases.